### PR TITLE
feat: 비슷한 항목 추가

### DIFF
--- a/backend/src/products/products.controller.ts
+++ b/backend/src/products/products.controller.ts
@@ -35,4 +35,10 @@ export class ProductsController {
     }
     return product;
   }
+
+  @Get(':id/related')
+  async getRelatedProducts(@Param('id') id: number) {
+    const relatedProducts = await this.productsService.getRelatedProducts(id);
+    return relatedProducts;
+  }
 }

--- a/frontend/src/11st-Home.tsx
+++ b/frontend/src/11st-Home.tsx
@@ -103,6 +103,69 @@ function TopNotice() {
   );
 }
 
+function FeaturedProductsGrid({ navigateTo }: { navigateTo: (path: string) => void }) {
+  const [products, setProducts] = useState<Product[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchFeaturedProducts = async () => {
+      try {
+        setLoading(true);
+        const data = await productService.getFeaturedProducts();
+        setProducts(data);
+      } catch (error) {
+        console.error('Error fetching featured products:', error);
+        setProducts([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchFeaturedProducts();
+  }, []);
+
+  if (loading) {
+    return (
+      <section className="mx-auto max-w-screen-2xl px-4">
+        <div className="mb-4">
+          <SectionHeader title="추천 상품" subtitle="지금 가장 인기 있는 상품들을 만나보세요" />
+        </div>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="animate-pulse">
+              <div className="aspect-square bg-gray-200 rounded-2xl mb-3"></div>
+              <div className="space-y-2">
+                <div className="h-4 bg-gray-200 rounded"></div>
+                <div className="h-6 bg-gray-200 rounded"></div>
+                <div className="h-4 bg-gray-200 rounded w-2/3"></div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="mx-auto max-w-screen-2xl px-4">
+      <div className="mb-4">
+        <SectionHeader title="추천 상품" subtitle="지금 가장 인기 있는 상품들을 만나보세요" />
+      </div>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+        {products.length > 0 ? (
+          products.map((p) => (
+            <ProductCard key={p.id} p={p} navigateTo={navigateTo} />
+          ))
+        ) : (
+          <div className="col-span-full text-center py-8 text-gray-500">
+            추천 상품이 없습니다.
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
 type HeaderProps = { 
   query: string; 
   setQuery: React.Dispatch<React.SetStateAction<string>>;
@@ -696,6 +759,7 @@ export default function ElevenStreetHome({ navigateTo }: ElevenStreetHomeProps) 
         <HeroCarousel />
         <PromoTiles />
         <DealsGrid query={query} navigateTo={navigateTo} />
+        <FeaturedProductsGrid navigateTo={navigateTo} />
       </main>
       <Footer />
     </div>

--- a/frontend/src/services/productService.ts
+++ b/frontend/src/services/productService.ts
@@ -69,5 +69,18 @@ export const productService = {
       console.error('인기 상품 조회 오류:', error);
       return [];
     }
+  },
+
+  async getRelatedProducts(id: number): Promise<Product[]> {
+    try {
+      const response = await fetch(`${API_BASE_URL}/products/${id}/related`);
+      if (!response.ok) {
+        throw new Error('관련 상품을 가져오는데 실패했습니다.');
+      }
+      return await response.json();
+    } catch (error) {
+      console.error(`관련 상품 조회 오류 (ID: ${id}):`, error);
+      return [];
+    }
   }
 };


### PR DESCRIPTION
## 📌 주요 변경 사항
### 백엔드 (NestJS)
- `ProductsController`
  - `GET /products/:id/related` 엔드포인트 추가 → 특정 상품과 같은 카테고리의 연관 상품 조회 가능
- `ProductsService`
  - `getRelatedProducts(productId: number)` 메서드 구현
    - 동일 카테고리 내 상품 최대 4개 반환
    - 현재 상품 제외
    - DTO 매핑 (`id`, `brand`, `name`, `price`, `img`, `category` 등)

### 프론트엔드 (React)
- **홈 화면 (`11st-Home.tsx`)**
  - `FeaturedProductsGrid` 컴포넌트 추가
  - 추천/인기 상품 영역 UI 및 로딩 스켈레톤 구현
- **상품 상세 (`ProductDetail.tsx`)**
  - 기존 더미 연관상품 제거
  - 실제 API 연동된 연관 상품 그리드 표시
  - 상품 클릭 시 해당 상품 상세 페이지로 이동 가능
- **서비스 (`productService.ts`)**
  - `getRelatedProducts(id: number)` 함수 추가 → 백엔드 연동

---

## 기대 동작
- 상품 상세 페이지 진입 시:
  - 선택한 상품 정보와 함께 **연관 상품 목록(최대 4개)** 표시됨
  - 연관 상품 클릭 시 해당 상품 상세 페이지로 이동
- 홈 화면에서:
  - **추천 상품 영역** 표시
  - API 응답 대기 중에는 스켈레톤 UI 출력

---

- **상품 상세 페이지**
  - 하단에 "연관 상품" 섹션 노출
- **홈 화면**
  - "추천 상품" 섹션 노출, 로딩 시 스켈레톤 표시
